### PR TITLE
FIX: do not show default site description in favor of login subheader

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -39,6 +39,11 @@ body.static-login {
 
   .login-welcome {
     font-size: var(--font-up-1);
+    .login-welcome__title {
+      p {
+        display: none;
+      }
+    }
   }
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -39,10 +39,8 @@ body.static-login {
 
   .login-welcome {
     font-size: var(--font-up-1);
-    .login-welcome__title {
-      p {
-        display: none;
-      }
+    .login-welcome__description {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Fixes: https://meta.discourse.org/t/trendy-login/206955/32